### PR TITLE
Fix Laravel 5.4 container compatibility

### DIFF
--- a/src/Torann/Registry/RegistryServiceProvider.php
+++ b/src/Torann/Registry/RegistryServiceProvider.php
@@ -61,7 +61,7 @@ class RegistryServiceProvider extends ServiceProvider {
      */
     protected function registerCache()
     {
-        $this->app['registry.cache'] = $this->app->share(function($app)
+        $this->app->singleton('registry.cache', function ($app)
         {
             $meta = $app->config->get('registry.cache_path');
             $timestampManager = $app->config->get('registry.timestamp_manager');


### PR DESCRIPTION
Have replaced 'share' method of the container to 'singleton' because in Laravel 5.4 'share' was removed